### PR TITLE
Mocking exceptions using http request to control theme.

### DIFF
--- a/java/testSocket/src/main/java/com/wawrzyniak/testsocket/Controller/ExceptionController.java
+++ b/java/testSocket/src/main/java/com/wawrzyniak/testsocket/Controller/ExceptionController.java
@@ -1,6 +1,7 @@
 package com.wawrzyniak.testsocket.Controller;
 
 import com.wawrzyniak.testsocket.Exceptions.RobotNotConfiguredException;
+import com.wawrzyniak.testsocket.Exceptions.WrongRequestException;
 import com.wawrzyniak.testsocket.Model.Records.ExceptionMessagePair;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -24,6 +25,14 @@ public class ExceptionController {
                 e.getClass().getSimpleName(),
                 e.getMessage());
 
+        return new ResponseEntity<>(nameMessagePair, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(value = WrongRequestException.class)
+    public ResponseEntity<ExceptionMessagePair> wrongRequest(Exception e){
+        ExceptionMessagePair nameMessagePair = new ExceptionMessagePair(
+                e.getClass().getSimpleName(),
+                e.getMessage());
         return new ResponseEntity<>(nameMessagePair, HttpStatus.BAD_REQUEST);
     }
 }

--- a/java/testSocket/src/main/java/com/wawrzyniak/testsocket/Controller/KukaCommController.java
+++ b/java/testSocket/src/main/java/com/wawrzyniak/testsocket/Controller/KukaCommController.java
@@ -1,7 +1,11 @@
 package com.wawrzyniak.testsocket.Controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wawrzyniak.testsocket.Exceptions.ExceptionTypes;
+import com.wawrzyniak.testsocket.Model.Records.ExceptionMessagePair;
 import com.wawrzyniak.testsocket.Model.Records.IpVariablePair;
+import com.wawrzyniak.testsocket.Model.Records.OutputWithErrors;
+import com.wawrzyniak.testsocket.Model.Types.VarType;
 import com.wawrzyniak.testsocket.Service.KukaMockService;
 import com.wawrzyniak.testsocket.Service.SessionManagerService;
 import org.slf4j.Logger;
@@ -11,6 +15,8 @@ import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
 import org.springframework.web.socket.handler.TextWebSocketHandler;
+
+import java.util.HashMap;
 
 public class KukaCommController extends TextWebSocketHandler {
     private static final Logger logger = LoggerFactory.getLogger(KukaCommController.class);
@@ -33,6 +39,16 @@ public class KukaCommController extends TextWebSocketHandler {
     public void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
         String request = message.getPayload();
         IpVariablePair data = mapper.readValue(request, IpVariablePair.class);
+        if (data.var() == VarType.WRONG) {
+            session.sendMessage(new TextMessage(mapper.writeValueAsString(
+                    new OutputWithErrors(
+                            new HashMap<>(), new ExceptionMessagePair(
+                            ExceptionTypes.WRONG_IP.getException().getClass().getSimpleName(),
+                            ExceptionTypes.WRONG_IP.getException().getMessage())
+                    ))));
+            logger.info("Mocked exception send to:1 " + session.getRemoteAddress().toString());
+            return;
+        }
         kukaService.addVariable(data.host(), data.var());
         sessionService.addVariable(session, data.host(), kukaService.getVariable(data.host(), data.var()));
 

--- a/java/testSocket/src/main/java/com/wawrzyniak/testsocket/Controller/KukaCommStaticDataController.java
+++ b/java/testSocket/src/main/java/com/wawrzyniak/testsocket/Controller/KukaCommStaticDataController.java
@@ -2,6 +2,10 @@ package com.wawrzyniak.testsocket.Controller;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.wawrzyniak.testsocket.Exceptions.RobotNotConfiguredException;
+import com.wawrzyniak.testsocket.Exceptions.WrongRequestException;
+import com.wawrzyniak.testsocket.Model.ExceptionMockingRequests.ClearExceptionRequest;
+import com.wawrzyniak.testsocket.Model.ExceptionMockingRequests.DisconnectRequest;
+import com.wawrzyniak.testsocket.Model.ExceptionMockingRequests.ExceptionToVariable;
 import com.wawrzyniak.testsocket.Model.ModelReading.ConfiguredRobotDTO;
 import com.wawrzyniak.testsocket.Model.Records.RobotData;
 import com.wawrzyniak.testsocket.Model.Value.KRLValue;
@@ -76,5 +80,20 @@ public class KukaCommStaticDataController {
     public KRLValue setValue(@RequestBody ValueSetRequest request) throws JsonProcessingException {
         logger.debug("Called endpoint: POST /configured, request body: " + request);
         return kukaService.setValue(request.getHost(), request.getVar(), request.getValue());
+    }
+
+    @PostMapping("exception/add")
+    public void addExceptionToVariable(@RequestBody ExceptionToVariable exception) throws WrongRequestException {
+        kukaService.addExceptionToVariable(exception.getHostIP(), exception.getVariable(), exception.getException());
+    }
+
+    @PostMapping("exception/clear")
+    public void clearExceptionFromVariable(@RequestBody ClearExceptionRequest exception) throws WrongRequestException {
+        kukaService.removeExceptionFromVariable(exception.getHostIP(), exception.getVariable());
+    }
+
+    @PostMapping("exception/disconnect")
+    public void disconnectRobot(@RequestBody DisconnectRequest request) throws WrongRequestException {
+        kukaService.disconnectRobot(request.getHostIP());
     }
 }

--- a/java/testSocket/src/main/java/com/wawrzyniak/testsocket/Exceptions/ExceptionTypes.java
+++ b/java/testSocket/src/main/java/com/wawrzyniak/testsocket/Exceptions/ExceptionTypes.java
@@ -1,0 +1,20 @@
+package com.wawrzyniak.testsocket.Exceptions;
+
+import java.io.IOException;
+
+public enum ExceptionTypes {
+    WRONG_IP(new WrongIpException("Cannot reach desired IP")),
+    WRONG_ID(new WrongIdException("Id of received message is not matching id of send message")),
+    EMPTY_BASE_OR_TOOL(new EmptyBaseOrToolException("Set tool and base of robot to check position of either")),
+    DISCONNECTED(new IOException("Exception thrown when connection with robot is lost."));
+
+    private final Exception exception;
+
+    ExceptionTypes(Exception e) {
+        exception = e;
+    }
+
+    public Exception getException() {
+        return exception;
+    }
+}

--- a/java/testSocket/src/main/java/com/wawrzyniak/testsocket/Exceptions/WrongRequestException.java
+++ b/java/testSocket/src/main/java/com/wawrzyniak/testsocket/Exceptions/WrongRequestException.java
@@ -1,0 +1,7 @@
+package com.wawrzyniak.testsocket.Exceptions;
+
+public class WrongRequestException extends Exception {
+    public WrongRequestException(String s) {
+        super(s);
+    }
+}

--- a/java/testSocket/src/main/java/com/wawrzyniak/testsocket/Model/ExceptionMockingRequests/ClearExceptionRequest.java
+++ b/java/testSocket/src/main/java/com/wawrzyniak/testsocket/Model/ExceptionMockingRequests/ClearExceptionRequest.java
@@ -1,0 +1,10 @@
+package com.wawrzyniak.testsocket.Model.ExceptionMockingRequests;
+
+import com.wawrzyniak.testsocket.Model.Types.VarType;
+import lombok.Data;
+
+@Data
+public class ClearExceptionRequest {
+    private String hostIP;
+    private VarType variable;
+}

--- a/java/testSocket/src/main/java/com/wawrzyniak/testsocket/Model/ExceptionMockingRequests/DisconnectRequest.java
+++ b/java/testSocket/src/main/java/com/wawrzyniak/testsocket/Model/ExceptionMockingRequests/DisconnectRequest.java
@@ -1,0 +1,8 @@
+package com.wawrzyniak.testsocket.Model.ExceptionMockingRequests;
+
+import lombok.Data;
+
+@Data
+public class DisconnectRequest {
+    private String hostIP;
+}

--- a/java/testSocket/src/main/java/com/wawrzyniak/testsocket/Model/ExceptionMockingRequests/ExceptionToVariable.java
+++ b/java/testSocket/src/main/java/com/wawrzyniak/testsocket/Model/ExceptionMockingRequests/ExceptionToVariable.java
@@ -1,0 +1,12 @@
+package com.wawrzyniak.testsocket.Model.ExceptionMockingRequests;
+
+import com.wawrzyniak.testsocket.Exceptions.ExceptionTypes;
+import com.wawrzyniak.testsocket.Model.Types.VarType;
+import lombok.Data;
+
+@Data
+public class ExceptionToVariable {
+    private String hostIP;
+    private VarType variable;
+    private ExceptionTypes exception;
+}

--- a/java/testSocket/src/main/java/com/wawrzyniak/testsocket/Model/Types/VarType.java
+++ b/java/testSocket/src/main/java/com/wawrzyniak/testsocket/Model/Types/VarType.java
@@ -11,7 +11,8 @@ public enum VarType {
     POSITION("$POS_ACT"),
     BASE_NUMBER("$ACT_BASE"),
     TOOL_NUMBER("$ACT_TOOL"),
-    JOINTS("$AXIS_ACT");
+    JOINTS("$AXIS_ACT"),
+    WRONG("Wrong id for debug");
 
     private final String value;
 
@@ -29,6 +30,9 @@ public enum VarType {
             }
             case JOINTS: {
                 yield new KRLJoints();
+            }
+            case WRONG: {
+                yield null;
             }
         };
         return new ValuePair(this.value, type);


### PR DESCRIPTION
There are 3 new endpoints:
* kuka-variable/exception/add

>{
    "hostIP":"192.168.1.50",
    "variable":"BASE",
    "exception":"WRONG_ID"
}

* kuka-variable/exception/clear

>{
    "hostIP":"192.168.1.50",
    "variable":"BASE",
}

* kuka-variable/exception/disconnect

>{
    "hostIP":"192.168.1.50",
}

Available values of exception in first request are:
* WRONG_ID
* EMPYT_BASE_OR_TOOL

Using second request will clear all exceptions from chosen variable.

Disconnecting chosen robot will result in adding `IOException` to all variables of chosen robot

Calling `WrongIpException` is done by requesting variable through websocket, using "WRONG" as variable type. 