### PR TITLE
Added continues motion to mocked robots

### DIFF
--- a/java/testSocket/src/main/java/com/wawrzyniak/testsocket/Controller/KukaCommStaticDataController.java
+++ b/java/testSocket/src/main/java/com/wawrzyniak/testsocket/Controller/KukaCommStaticDataController.java
@@ -7,6 +7,7 @@ import com.wawrzyniak.testsocket.Model.ExceptionMockingRequests.ClearExceptionRe
 import com.wawrzyniak.testsocket.Model.ExceptionMockingRequests.DisconnectRequest;
 import com.wawrzyniak.testsocket.Model.ExceptionMockingRequests.ExceptionToVariable;
 import com.wawrzyniak.testsocket.Model.ModelReading.ConfiguredRobotDTO;
+import com.wawrzyniak.testsocket.Model.MotionDescription;
 import com.wawrzyniak.testsocket.Model.Records.RobotData;
 import com.wawrzyniak.testsocket.Model.Value.KRLValue;
 import com.wawrzyniak.testsocket.Model.ValueSetRequest;
@@ -96,5 +97,11 @@ public class KukaCommStaticDataController {
     @PostMapping("exception/disconnect")
     public void disconnectRobot(@RequestBody DisconnectRequest request) throws WrongRequestException {
         kukaService.disconnectRobot(request.getHostIP());
+    }
+
+    @PostMapping("move")
+    public void addMotion(@RequestBody MotionDescription md) throws WrongRequestException {
+        logger.debug("Called endpoint: POST /move, request body: " + md);
+        kukaService.addMotion(md);
     }
 }

--- a/java/testSocket/src/main/java/com/wawrzyniak/testsocket/Model/MotionDescription.java
+++ b/java/testSocket/src/main/java/com/wawrzyniak/testsocket/Model/MotionDescription.java
@@ -1,0 +1,11 @@
+package com.wawrzyniak.testsocket.Model;
+
+import com.wawrzyniak.testsocket.Model.Value.KRLFrame;
+import lombok.Data;
+
+@Data
+public class MotionDescription {
+    private String ipAddress;
+    private KRLFrame tcpPosition;
+    private Integer desiredTime;
+}

--- a/java/testSocket/src/main/java/com/wawrzyniak/testsocket/Model/Records/Vector3.java
+++ b/java/testSocket/src/main/java/com/wawrzyniak/testsocket/Model/Records/Vector3.java
@@ -1,4 +1,18 @@
 package com.wawrzyniak.testsocket.Model.Records;
 
 public record Vector3 (double x, double y, double z){
+    public Vector3 add(Vector3 vector) {
+         double x = this.x + vector.x();
+         double y = this.y + vector.y();
+         double z = this.z + vector.z();
+         return new Vector3(x, y, z);
+    }
+
+    public Vector3 difference(Vector3 vector) {
+        return new Vector3(vector.x() - this.x, vector.y() - this.y, vector.z() - this.z);
+    }
+
+    public Vector3 divide(int divider){
+        return new Vector3(this.x / divider, this.y / divider,this.z / divider);
+    }
 }

--- a/java/testSocket/src/main/java/com/wawrzyniak/testsocket/Model/Value/KRLFrame.java
+++ b/java/testSocket/src/main/java/com/wawrzyniak/testsocket/Model/Value/KRLFrame.java
@@ -51,4 +51,20 @@ public class KRLFrame extends JsonFormatter implements KRLValue {
         position = new Vector3(rand.nextDouble(50, 250), rand.nextDouble(50, 250), rand.nextDouble(50, 250));
         rotation = new Vector3(rand.nextDouble(50, 250), rand.nextDouble(50, 250), rand.nextDouble(50, 250));
     }
+
+    public void transform(Vector3 move){
+        position = position.add(move);
+    }
+
+    public void rotate(Vector3 rotate){
+        rotation = rotation.add(rotate);
+    }
+
+    public Vector3 calculatePositionShift(Vector3 goal) {
+        return position.difference(goal);
+    }
+
+    public Vector3 calculateRotationShift(Vector3 goal) {
+        return rotation.difference(goal);
+    }
 }

--- a/java/testSocket/src/main/java/com/wawrzyniak/testsocket/Service/KukaMockService.java
+++ b/java/testSocket/src/main/java/com/wawrzyniak/testsocket/Service/KukaMockService.java
@@ -87,7 +87,7 @@ public class KukaMockService {
             throw new WrongRequestException("Robot with chosen ip is not connected to websocket at the moment. Try to reach it through websocket first.");
         }
         if (!variables.get(hostIp).containsKey(variable)) {
-            throw new WrongRequestException("Requested variable does not exists. It would be appropriate to firstly request reading fo chosen variable through websocket.");
+            throw new WrongRequestException("Requested variable does not exist. It would be appropriate to firstly request reading of chosen variable through websocket.");
         }
         variables.get(hostIp).get(variable).addReadException(exception.getException());
     }
@@ -97,7 +97,7 @@ public class KukaMockService {
             throw new WrongRequestException("Robot with chosen ip is not connected to websocket at the moment. Try to reach it through websocket first.");
         }
         if (!variables.get(hostIp).containsKey(variable)) {
-            throw new WrongRequestException("Requested variable does not exists. It would be appropriate to firstly request reading fo chosen variable through websocket.");
+            throw new WrongRequestException("Requested variable does not exist. It would be appropriate to firstly request reading of chosen variable through websocket.");
         }
         variables.get(hostIp).get(variable).clearExceptions();
     }
@@ -116,7 +116,7 @@ public class KukaMockService {
             throw new WrongRequestException("Robot with chosen ip is not connected to websocket at the moment. Try to reach it through websocket first.");
         }
         if (!variables.get(md.getIpAddress()).containsKey(VarType.POSITION)) {
-            throw new WrongRequestException("Requested variable does not exists. It would be appropriate to firstly request reading fo chosen variable through websocket.");
+            throw new WrongRequestException("Requested variable does not exist. It would be appropriate to firstly request reading of chosen variable through websocket.");
         }
         if (!robotMotions.containsKey(md.getIpAddress())) {
             robotMotions.put(md.getIpAddress(), new MotionHandlerThread(variables.get(md.getIpAddress()).get(VarType.POSITION)));

--- a/java/testSocket/src/main/java/com/wawrzyniak/testsocket/Service/MotionHandlerThread.java
+++ b/java/testSocket/src/main/java/com/wawrzyniak/testsocket/Service/MotionHandlerThread.java
@@ -1,0 +1,55 @@
+package com.wawrzyniak.testsocket.Service;
+
+import com.wawrzyniak.testsocket.Model.KRLVar;
+import com.wawrzyniak.testsocket.Model.MotionDescription;
+import com.wawrzyniak.testsocket.Model.Records.Vector3;
+import com.wawrzyniak.testsocket.Model.Value.KRLFrame;
+
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+public class MotionHandlerThread extends Thread{
+
+    private final Queue<MotionDescription> motions;
+    private final KRLVar tcpPosition;
+
+    public MotionHandlerThread(KRLVar tcp){
+        tcpPosition = tcp;
+        motions = new ConcurrentLinkedQueue<>();
+    }
+    public void addMotion(MotionDescription md) {
+        motions.add(md);
+    }
+
+    @Override
+    public void run() {
+        while(!Thread.currentThread().isInterrupted()) {
+            while (!motions.isEmpty()) {
+                MotionDescription motion = motions.poll();
+                int steps = motion.getDesiredTime()/5;
+                KRLFrame tcp = (KRLFrame) tcpPosition.getValue();
+                Vector3 distance = tcp.calculatePositionShift(motion.getTcpPosition().getPosition());
+                Vector3 rotation = tcp.calculateRotationShift(motion.getTcpPosition().getRotation());
+                Vector3 distanceStep = distance.divide(steps);
+                Vector3 rotationStep = rotation.divide(steps);
+                for (int i = 0; i < steps; i++){
+                    tcp.transform(distanceStep);
+                    tcp.rotate(rotationStep);
+                    tcpPosition.setValue(tcp);
+                    try {
+                        Thread.sleep(5);
+                    } catch (InterruptedException e){
+                        Thread.currentThread().interrupt();
+                    }
+                }
+                tcpPosition.setValue(motion.getTcpPosition());
+            }
+
+            try {
+                Thread.sleep(5);
+            } catch (InterruptedException e){
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Utility to create fluent motions between desired TCP position using http POST request:

* kuka-variable/move
```
{
    "ipAddress":"192.168.1.50",
    "tcpPosition":{
         "position": {
                        "x": 0,
                        "y": 0,
                        "z": 0
                    },
                    "rotation": {
                        "x": 0,
                        "y": 0,
                        "z": 0
                    }
    },
    "desiredTime":10000
}
```
`ipAddress` - IP of robot witch will be affected by request: String 
`tcpPosition` - goal position of tcp after performing movement: KRLFrame
`desiredTime` - time of full motion from actual position to desired position in ms: Integer

Sending multiple requests will manifest in creating queue of motions performed by tcp using provided data.

Calling for robot (ip address) that is not monitored in websocket will cause exception.

